### PR TITLE
Disable admin interface when offline

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -17,7 +17,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 
 export default function AdminPage() {
   const [activeTab, setActiveTab] = useState<AdminTab>("dashboard");
-  const { isAdmin, isLoading, error } = useAdmin();
+  const { isAdmin, isLoading, error, offlineMode } = useAdmin();
   const router = useRouter();
   const [retryCount, setRetryCount] = useState(0);
 
@@ -85,7 +85,7 @@ export default function AdminPage() {
     );
   }
 
-  // Si l'utilisateur n'est pas administrateur, afficher un message d'erreur
+  // Si l'utilisateur n'est pas administrateur
   if (!isAdmin) {
     return (
       <div className="pt-32 pb-16 flex items-center justify-center min-h-screen">
@@ -94,7 +94,9 @@ export default function AdminPage() {
             <Alert variant="destructive" className="mb-4">
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
-                Vous n'avez pas les droits d'accès à cette page.
+                {offlineMode
+                  ? "L'interface d'administration est indisponible hors ligne."
+                  : "Vous n'avez pas les droits d'accès à cette page."}
               </AlertDescription>
             </Alert>
             <Button className="w-full" onClick={() => router.push('/dashboard')}>

--- a/contexts/AdminContext.tsx
+++ b/contexts/AdminContext.tsx
@@ -44,11 +44,15 @@ export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
         // Vérifier d'abord si nous sommes en ligne
         if (!navigator.onLine || !connectionStatus.online) {
           console.warn('Offline mode detected during admin check');
-          setError("Mode hors ligne : certaines fonctionnalités administratives peuvent être limitées");
+          setError("Interface d'administration indisponible hors ligne");
           setOfflineMode(true);
-          // En mode hors ligne, nous supposons que l'utilisateur est admin pour l'interface de démo
-          setIsAdmin(true);
+          setIsAdmin(false);
           setIsLoading(false);
+          toast({
+            variant: "warning",
+            title: "Mode hors ligne",
+            description: "L'interface d'administration est indisponible hors ligne.",
+          });
           return;
         }
 
@@ -62,8 +66,13 @@ export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
           // Si nous avons une erreur de type "network error", activer le mode hors ligne
           if (error.message?.includes('network') || error.message?.includes('fetch') || !navigator.onLine) {
             setOfflineMode(true);
-            setIsAdmin(true); // Pour la démo, on considère l'utilisateur comme admin
-            setError("Mode hors ligne : certaines fonctionnalités administratives peuvent être limitées");
+            setIsAdmin(false);
+            setError("Interface d'administration indisponible hors ligne");
+            toast({
+              variant: "warning",
+              title: "Mode hors ligne",
+              description: "L'interface d'administration est indisponible hors ligne.",
+            });
           } else {
             setError(error.message);
             throw error;
@@ -1596,6 +1605,7 @@ export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
   const value = {
     isAdmin,
     isLoading,
+    offlineMode,
     error,
     users,
     courses,

--- a/lib/types/admin-types.ts
+++ b/lib/types/admin-types.ts
@@ -118,6 +118,7 @@ export interface DashboardData {
 export interface AdminContextType {
   isAdmin: boolean;
   isLoading: boolean;
+  offlineMode: boolean;
   error: string | null;
   users: AdminUser[];
   courses: CourseData[];


### PR DESCRIPTION
## Summary
- expose `offlineMode` in AdminContext
- block admin access when offline instead of granting rights
- display offline warning when visiting admin page without connection

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_684038409b088321b14f9485de80d872