### PR TITLE
Fix alert variant

### DIFF
--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -11,6 +11,8 @@ const alertVariants = cva(
         default: "bg-background text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        warning:
+          "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/30 dark:bg-amber-900/20 dark:text-amber-300 [&>svg]:text-amber-700 dark:[&>svg]:text-amber-400",
       },
     },
     defaultVariants: {

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -14,6 +14,10 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        success:
+          "border-transparent bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+        warning:
+          "border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
         outline: "text-foreground",
       },
     },


### PR DESCRIPTION
## Summary
- support custom warning style in Alert
- add success and warning badge styles

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403b0187008321875b80809827bde5