### PR TITLE
Fix tests and build

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -241,7 +241,7 @@ export default function ProfilePage() {
                 </CardHeader>
                 <CardContent>
                   {profileError && (
-                    <Alert variant="destructive\" className="mb-6">
+                    <Alert variant="destructive" className="mb-6">
                       <AlertCircle className="h-4 w-4" />
                       <AlertDescription>{profileError}</AlertDescription>
                     </Alert>
@@ -322,7 +322,7 @@ export default function ProfilePage() {
                 </CardHeader>
                 <CardContent>
                   {passwordError && (
-                    <Alert variant="destructive\" className="mb-6">
+                    <Alert variant="destructive" className="mb-6">
                       <AlertCircle className="h-4 w-4" />
                       <AlertDescription>{passwordError}</AlertDescription>
                     </Alert>

--- a/app/program/modules-list.tsx
+++ b/app/program/modules-list.tsx
@@ -10,6 +10,18 @@ import {
 import { Check, Clock, FileText, Target } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
+interface ModuleItem {
+  title: string;
+  objectives: string[];
+  deliverables: string[];
+  duration: string;
+}
+
+interface Module {
+  phase: string;
+  items: ModuleItem[];
+}
+
 export function ModulesList() {
   const [activeTab, setActiveTab] = useState("all");
   const [isMounted, setIsMounted] = useState(false);
@@ -24,7 +36,7 @@ export function ModulesList() {
     });
   }, []);
   
-  const modules = [
+  const modules: Module[] = [
     {
       phase: "Phase 1: Fondamentaux de l'IA",
       items: [
@@ -119,7 +131,7 @@ export function ModulesList() {
     }
   ];
 
-  const renderModuleContent = (modulesList) => {
+  const renderModuleContent = (modulesList: Module[]) => {
     return modulesList.map((module, moduleIndex) => (
       <div key={moduleIndex} className="mb-12 section-animated animate-section-in">
         <h3 className="text-2xl font-bold mb-6">{module.phase}</h3>
@@ -197,7 +209,7 @@ export function ModulesList() {
         
         <div className="max-w-4xl mx-auto space-y-10">
           {isMounted ? (
-            <Tabs defaultValue="all\" value={activeTab} onValueChange={setActiveTab} className="mb-8">
+            <Tabs defaultValue="all" value={activeTab} onValueChange={setActiveTab} className="mb-8">
               <div className="flex justify-center mb-6">
                 <TabsList className="bg-muted/70 p-1">
                   <TabsTrigger value="all" className="rounded-md data-[state=active]:bg-card data-[state=active]:shadow-sm">Toutes les phases</TabsTrigger>

--- a/components/admin/connection-troubleshooter.tsx
+++ b/components/admin/connection-troubleshooter.tsx
@@ -7,23 +7,24 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { 
-  CheckCircle2, 
-  XCircle, 
-  RefreshCw, 
-  FileCog, 
-  Shield, 
-  Terminal, 
-  Loader2, 
+  CheckCircle2,
+  XCircle,
+  RefreshCw,
+  FileCog,
+  Shield,
+  Terminal,
+  Loader2,
   ArrowRight,
   CheckCheck,
-  Database
+  Database,
+  AlertTriangle
 } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 import { useAdmin } from "@/contexts/AdminContext";
 
 export function ConnectionTroubleshooter() {
   const [isRunningTest, setIsRunningTest] = useState(false);
-  const [results, setResults] = useState<any>(null);
+  const [results, setResults] = useState<Record<string, any> | null>(null);
   const [supabaseUrl, setSupabaseUrl] = useState(process.env.NEXT_PUBLIC_SUPABASE_URL || '');
   const [supabaseKey, setSupabaseKey] = useState('');
   const [showKeyInput, setShowKeyInput] = useState(false);
@@ -103,7 +104,7 @@ export function ConnectionTroubleshooter() {
         // Check if specific tables exist
         if (!dbError) {
           const tables = ['profiles', 'courses', 'modules', 'coupons', 'user_roles'];
-          const tableResults = {};
+          const tableResults: Record<string, boolean> = {};
           
           for (const table of tables) {
             try {
@@ -244,7 +245,7 @@ export function ConnectionTroubleshooter() {
                   className="mt-1"
                 />
                 <p className="text-xs text-muted-foreground mt-1">
-                  La clé anonyme (anon public) se trouve dans Project Settings > API
+                  La clé anonyme (anon public) se trouve dans Project Settings &gt; API
                 </p>
               </div>
             )}

--- a/components/data-visualization/ai-growth-charts.tsx
+++ b/components/data-visualization/ai-growth-charts.tsx
@@ -49,7 +49,7 @@ import {
 export function AIGrowthCharts() {
   const [activeTab, setActiveTab] = useState("marché");
   const [isMounted, setIsMounted] = useState(false);
-  const [hoveredIndex, setHoveredIndex] = useState(null);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   
   // Initialize component on client side
   useEffect(() => {
@@ -57,7 +57,7 @@ export function AIGrowthCharts() {
   }, []);
 
   // Market data - Croissance du marché mondial de l'IA
-  const marketGrowthData = [
+  const marketGrowthData: { year: string; value: number }[] = [
     { year: "2022", value: 150 },
     { year: "2023", value: 220 },
     { year: "2024", value: 330 },
@@ -70,7 +70,7 @@ export function AIGrowthCharts() {
   ];
 
   // Impact économique par région
-  const economicImpactData = [
+  const economicImpactData: { name: string; value: number }[] = [
     { name: "Amérique du Nord", value: 3600 },
     { name: "Europe", value: 2800 },
     { name: "Chine", value: 3200 },
@@ -80,7 +80,7 @@ export function AIGrowthCharts() {
   ];
 
   // Sectors data - Distribution de l'IA par secteur
-  const sectorDistributionData = [
+  const sectorDistributionData: { name: string; value: number }[] = [
     { name: "Santé", value: 24 },
     { name: "Finance", value: 21 },
     { name: "Retail", value: 16 },
@@ -91,7 +91,7 @@ export function AIGrowthCharts() {
   ];
   
   // Croissance par secteur (%)
-  const sectorGrowthData = [
+  const sectorGrowthData: { sector: string; growth: number }[] = [
     { sector: "Santé", growth: 42 },
     { sector: "Finance", growth: 38 },
     { sector: "Retail", growth: 35 },
@@ -102,7 +102,7 @@ export function AIGrowthCharts() {
   ];
   
   // Investissements mondiaux en IA par secteur (milliards $)
-  const sectorInvestmentData = [
+  const sectorInvestmentData: { sector: string; value: number }[] = [
     { sector: "Santé", value: 43.2 },
     { sector: "Finance", value: 38.6 },
     { sector: "Retail", value: 28.5 },
@@ -113,7 +113,7 @@ export function AIGrowthCharts() {
   ];
 
   // Productivity data - Gain de productivité moyen par cas d'usage
-  const productivityGainData = [
+  const productivityGainData: { useCase: string; gain: number }[] = [
     { useCase: "Automatisation des processus", gain: 48 },
     { useCase: "Analyse de données", gain: 42 },
     { useCase: "Génération de contenu", gain: 39 },
@@ -124,7 +124,7 @@ export function AIGrowthCharts() {
   ];
   
   // Économies de temps hebdomadaires par profession (heures)
-  const timeSavingsData = [
+  const timeSavingsData: { profession: string; value: number }[] = [
     { profession: "Marketing", value: 12.5 },
     { profession: "Finance", value: 9.8 },
     { profession: "Juridique", value: 8.7 },
@@ -135,7 +135,7 @@ export function AIGrowthCharts() {
   ];
   
   // Évolution du ROI des projets IA (%)
-  const roiEvolutionData = [
+  const roiEvolutionData: { year: string; roi: number }[] = [
     { year: "2020", roi: 125 },
     { year: "2021", roi: 168 },
     { year: "2022", roi: 205 },
@@ -145,7 +145,7 @@ export function AIGrowthCharts() {
   ];
 
   // Employment data - Création d'emplois vs. Automatisation
-  const jobsData = [
+  const jobsData: { year: string; created: number; automated: number }[] = [
     { year: "2022", created: 0.8, automated: 0.4 },
     { year: "2023", created: 1.1, automated: 0.6 },
     { year: "2024", created: 1.5, automated: 0.8 },
@@ -158,7 +158,7 @@ export function AIGrowthCharts() {
   ];
   
   // Top 5 compétences IA les plus demandées (indice de demande)
-  const skillsDemandData = [
+  const skillsDemandData: { skill: string; value: number }[] = [
     { skill: "Prompt Engineering", value: 95 },
     { skill: "Data Analysis", value: 90 },
     { skill: "LLM Fine-tuning", value: 85 },
@@ -167,7 +167,7 @@ export function AIGrowthCharts() {
   ];
   
   // Estimation de nouveaux métiers créés par l'IA
-  const newJobsData = [
+  const newJobsData: { category: string; value: number }[] = [
     { category: "IA Gouvernance", value: 320 },
     { category: "Prompt Engineering", value: 280 },
     { category: "IA Éthique", value: 240 },
@@ -188,7 +188,7 @@ export function AIGrowthCharts() {
   ];
   
   // Hover animation for pie charts
-  const renderActiveShape = (props) => {
+  const renderActiveShape = (props: any) => {
     const { 
       cx, cy, innerRadius, outerRadius, startAngle, endAngle,
       fill, payload, percent, value
@@ -251,12 +251,12 @@ export function AIGrowthCharts() {
   };
 
   // Custom tooltip for better design
-  const CustomTooltip = ({ active, payload, label, valuePrefix, valueSuffix }) => {
+  const CustomTooltip = ({ active, payload, label, valuePrefix, valueSuffix }: any) => {
     if (active && payload && payload.length) {
       return (
         <div className="bg-card border border-border/40 p-3 rounded-md shadow-lg">
           <p className="font-medium">{label}</p>
-          {payload.map((entry, index) => (
+          {payload.map((entry: any, index: number) => (
             <p key={index} style={{ color: entry.color }} className="text-sm mt-1">
               {entry.name}: {valuePrefix || ""}{entry.value.toLocaleString()}{valueSuffix || ""}
             </p>
@@ -482,7 +482,7 @@ export function AIGrowthCharts() {
                         <ResponsiveContainer width="100%" height="100%">
                           <PieChart className="chart-animated">
                             <Pie
-                              activeIndex={hoveredIndex}
+                              activeIndex={hoveredIndex ?? undefined}
                               activeShape={renderActiveShape}
                               data={sectorDistributionData}
                               cx="50%"
@@ -552,7 +552,7 @@ export function AIGrowthCharts() {
                                   fill={COLORS[index % COLORS.length]} 
                                 />
                               ))}
-                              <LabelList dataKey="growth" position="top" formatter={(value) => `${value}%`} />
+                              <LabelList dataKey="growth" position="top" formatter={(value: any) => `${value}%`} />
                             </Bar>
                           </BarChart>
                         </ResponsiveContainer>
@@ -650,7 +650,7 @@ export function AIGrowthCharts() {
                               barSize={30} 
                               radius={[0, 4, 4, 0]}
                             >
-                              <LabelList dataKey="gain" position="right" formatter={(value) => `${value}%`} />
+                              <LabelList dataKey="gain" position="right" formatter={(value: any) => `${value}%`} />
                             </Bar>
                           </BarChart>
                         </ResponsiveContainer>
@@ -696,7 +696,7 @@ export function AIGrowthCharts() {
                               barSize={40} 
                               radius={[4, 4, 0, 0]}
                             >
-                              <LabelList dataKey="value" position="top" formatter={(value) => `${value}h`} />
+                              <LabelList dataKey="value" position="top" formatter={(value: any) => `${value}h`} />
                             </Bar>
                           </BarChart>
                         </ResponsiveContainer>

--- a/components/data-visualization/simple-stats.tsx
+++ b/components/data-visualization/simple-stats.tsx
@@ -116,12 +116,12 @@ export function SimpleStats() {
   ];
 
   // Formatter pour les tooltips
-  const CustomTooltip = ({ active, payload, label, valuePrefix, valueSuffix }) => {
+  const CustomTooltip = ({ active, payload, label, valuePrefix, valueSuffix }: any) => {
     if (active && payload && payload.length) {
       return (
         <div className="p-3 bg-background border border-border rounded-md shadow-lg">
           <p className="text-sm font-bold">{label}</p>
-          {payload.map((entry, index) => (
+          {payload.map((entry: any, index: number) => (
             <p key={index} style={{ color: entry.color }} className="text-sm mt-1">
               {entry.name}: {valuePrefix || ""}{entry.value.toLocaleString()}{valueSuffix || ""}
             </p>
@@ -340,7 +340,7 @@ export function SimpleStats() {
                       label={({name, percent}) => `${name}: ${(percent * 100).toFixed(0)}%`}
                       labelLine={true}
                     >
-                      {sectorData.map((entry, index) => (
+                      {sectorData.map((entry: any, index: number) => (
                         <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                       ))}
                     </Pie>
@@ -402,7 +402,7 @@ export function SimpleStats() {
                       barSize={30} 
                       radius={[4, 4, 0, 0]}
                     >
-                      {sectorGrowthData.map((entry, index) => (
+                      {sectorGrowthData.map((entry: any, index: number) => (
                         <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                       ))}
                     </Bar>
@@ -463,7 +463,7 @@ export function SimpleStats() {
                       radius={[0, 4, 4, 0]}
                     >
                       <Label position="right" fill="currentColor" fontSize={12} />
-                      {productivityData.map((entry, index) => (
+                      {productivityData.map((entry: any, index: number) => (
                         <Cell key={`cell-${index}`} fill={COLORS[(index + 5) % COLORS.length]} />
                       ))}
                     </Bar>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -188,7 +188,7 @@ export function Header() {
           {!isLoading && user ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost\" className="rounded-full p-0 flex items-center space-x-2 h-auto hover:bg-background">
+                <Button variant="ghost" className="rounded-full p-0 flex items-center space-x-2 h-auto hover:bg-background">
                   <Avatar className="h-10 w-10 border-2 border-indigo-500/20 transition-all duration-300 hover:border-indigo-500">
                     <AvatarImage 
                       src={user.avatar_url || "https://images.pexels.com/photos/774909/pexels-photo-774909.jpeg?auto=compress&cs=tinysrgb&w=400"} 

--- a/components/program/modules-list.tsx
+++ b/components/program/modules-list.tsx
@@ -10,6 +10,18 @@ import {
 import { Check, Clock, FileText, Target } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
+interface ModuleItem {
+  title: string;
+  objectives: string[];
+  deliverables: string[];
+  duration: string;
+}
+
+interface Module {
+  phase: string;
+  items: ModuleItem[];
+}
+
 export function ModulesList() {
   const [activeTab, setActiveTab] = useState("all");
   const [isMounted, setIsMounted] = useState(false);
@@ -25,7 +37,7 @@ export function ModulesList() {
     });
   }, []);
   
-  const modules = [
+  const modules: Module[] = [
     {
       phase: "Phase 1: Fondamentaux de l'IA",
       items: [
@@ -120,7 +132,7 @@ export function ModulesList() {
     }
   ];
 
-  const renderModuleContent = (modulesList) => {
+  const renderModuleContent = (modulesList: Module[]) => {
     return modulesList.map((module, moduleIndex) => (
       <div key={moduleIndex} className="mb-12">
         <h3 className="text-2xl font-bold mb-6">{module.phase}</h3>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -78,7 +78,7 @@ export function HeroSection() {
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12">
             {user ? (
               <>
-                <Button asChild size="lg\" className="h-12 px-8 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 hover:from-pink-500 hover:via-purple-500 hover:to-indigo-500 transition-all duration-500 shadow-lg hover:shadow-indigo-500/20 group rounded-full">
+                <Button asChild size="lg" className="h-12 px-8 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 hover:from-pink-500 hover:via-purple-500 hover:to-indigo-500 transition-all duration-500 shadow-lg hover:shadow-indigo-500/20 group rounded-full">
                   <Link href="/dashboard">
                     <span className="flex items-center">
                       <LayoutDashboard className="h-4 w-4 mr-2" />

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -11,6 +11,8 @@ const alertVariants = cva(
         default: "bg-background text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        warning:
+          "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/30 dark:bg-amber-900/20 dark:text-amber-300 [&>svg]:text-amber-700 dark:[&>svg]:text-amber-400",
       },
     },
     defaultVariants: {

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -14,6 +14,10 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        success:
+          "border-transparent bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+        warning:
+          "border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
         outline: "text-foreground",
       },
     },

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -32,6 +32,8 @@ const toastVariants = cva(
         default: 'border bg-background text-foreground',
         destructive:
           'destructive group border-destructive bg-destructive text-destructive-foreground',
+        warning:
+          'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/30 dark:bg-amber-900/20 dark:text-amber-300',
       },
     },
     defaultVariants: {

--- a/contexts/AdminContext.tsx
+++ b/contexts/AdminContext.tsx
@@ -49,7 +49,7 @@ export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
           setIsAdmin(false);
           setIsLoading(false);
           toast({
-            variant: "warning",
+            variant: "destructive",
             title: "Mode hors ligne",
             description: "L'interface d'administration est indisponible hors ligne.",
           });

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -104,8 +104,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         options: {
           data: metadata,
           emailRedirectTo: `${window.location.origin}/auth/callback`,
-          // Désactiver la vérification d'email pour l'environnement de développement
-          emailConfirm: false
         },
       });
 
@@ -131,16 +129,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const { data: profile } = await supabase
           .from('profiles')
           .select('*')
-          .eq('id', data.user.id)
+          .eq('id', data.user?.id || '')
           .single();
 
         setAuthState({
           user: {
-            id: data.user.id,
-            email: data.user.email || '',
-            full_name: profile?.full_name || data.user.user_metadata?.full_name,
-            avatar_url: profile?.avatar_url || data.user.user_metadata?.avatar_url,
-            created_at: data.user.created_at,
+            id: data.user?.id || '',
+            email: data.user?.email || '',
+            full_name: profile?.full_name || data.user?.user_metadata?.full_name,
+            avatar_url: profile?.avatar_url || data.user?.user_metadata?.avatar_url,
+            created_at: data.user?.created_at || '',
           },
           session: data.session,
           isLoading: false,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -97,7 +97,7 @@ const classifyError = (error: any): SupabaseErrorType => {
 };
 
 // Enhanced fetch wrapper with detailed error handling and timeout
-const enhancedFetch = async (...args) => {
+const enhancedFetch = async (...args: Parameters<typeof fetch>) => {
   try {
     // If we're offline, fail fast
     if (!connectionStatus.online) {

--- a/lib/types/admin-types.ts
+++ b/lib/types/admin-types.ts
@@ -22,6 +22,7 @@ export interface CourseData {
   phase: string;
   duration: string;
   status: 'published' | 'draft';
+  order_index: number;
   created_at: string;
   updated_at: string;
   modules_count?: number;
@@ -135,6 +136,7 @@ export interface AdminContextType {
   createModule: (module: Partial<ModuleData>) => Promise<ModuleData | null>;
   updateModule: (id: string, module: Partial<ModuleData>) => Promise<ModuleData | null>;
   deleteModule: (id: string) => Promise<void>;
+  loadCoupons: () => Promise<void>;
   createCoupon: (coupon: Partial<CouponData>) => Promise<CouponData | null>;
   updateCoupon: (id: string, coupon: Partial<CouponData>) => Promise<CouponData | null>;
   deleteCoupon: (id: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- fix alert variants in profile and password forms
- type modules list utilities
- patch connection troubleshooter and data viz components to satisfy TypeScript
- adjust toast variants to support "warning"
- harden supabase client and auth logic for typings

## Testing
- `npm run test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68403b0187008321875b80809827bde5