### PR TITLE
Add classifyError and withRetry tests

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -65,7 +65,7 @@ if (typeof window !== 'undefined') {
 }
 
 // Function to classify error types based on response and error details
-const classifyError = (error: any): SupabaseErrorType => {
+export const classifyError = (error: any): SupabaseErrorType => {
   // Check for browser environment before accessing navigator
   const isOffline = typeof window !== 'undefined' && typeof navigator !== 'undefined' && !navigator.onLine;
   
@@ -207,7 +207,7 @@ const enhancedFetch = async (...args: Parameters<typeof fetch>) => {
 };
 
 // Retry strategy with exponential backoff
-const withRetry = async (fn, maxRetries = 3) => {
+export const withRetry = async (fn: () => Promise<any>, maxRetries = 3) => {
   let lastError;
   
   for (let attempt = 0; attempt <= maxRetries; attempt++) {

--- a/tests/supabase.retry.test.ts
+++ b/tests/supabase.retry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({}))
+}))
+
+const env = process.env
+
+beforeEach(() => {
+  vi.resetModules()
+  process.env = { ...env, NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co', NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon' }
+})
+
+afterEach(() => {
+  process.env = env
+  vi.restoreAllMocks()
+  // cleanup navigator/window mocks
+  delete (global as any).window
+  delete (global as any).navigator
+})
+
+describe('classifyError', () => {
+  it('maps offline scenario to NETWORK_ERROR', async () => {
+    const mod = await import('../lib/supabase')
+    ;(global as any).window = {}
+    Object.defineProperty(global, 'navigator', { value: { onLine: false }, writable: true, configurable: true })
+    const result = mod.classifyError(new Error('offline'))
+    expect(result).toBe(mod.SupabaseErrorType.NETWORK_ERROR)
+  })
+
+  it('maps aborted requests to NETWORK_ERROR', async () => {
+    const mod = await import('../lib/supabase')
+    const err = new TypeError('Failed to fetch')
+    const result = mod.classifyError(err)
+    expect(result).toBe(mod.SupabaseErrorType.NETWORK_ERROR)
+  })
+
+  it('maps HTTP 5xx to SERVER_ERROR', async () => {
+    const mod = await import('../lib/supabase')
+    const result = mod.classifyError({ status: 503 })
+    expect(result).toBe(mod.SupabaseErrorType.SERVER_ERROR)
+  })
+})
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retries with exponential backoff on failure and eventually succeeds', async () => {
+    const mod = await import('../lib/supabase')
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce({ status: 503 })
+      .mockResolvedValue('ok')
+
+    const timeout = vi.spyOn(global, 'setTimeout')
+
+    const promise = mod.withRetry(fn, 3)
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(timeout.mock.calls[0][1]).toBeGreaterThanOrEqual(1000)
+    expect(timeout.mock.calls[1][1]).toBeGreaterThanOrEqual(2000)
+  })
+
+  it('stops retrying on AUTH_ERROR', async () => {
+    const mod = await import('../lib/supabase')
+    const fn = vi.fn().mockRejectedValue({ status: 401 })
+
+    await expect(mod.withRetry(fn, 3)).rejects.toBeDefined()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries when offline and eventually fails after max retries', async () => {
+    const mod = await import('../lib/supabase')
+    ;(global as any).window = {}
+    Object.defineProperty(global, 'navigator', { value: { onLine: false }, writable: true, configurable: true })
+
+    const fn = vi.fn().mockRejectedValue(new Error('offline'))
+    const promise = mod.withRetry(fn, 1).catch(e => e)
+
+    await vi.runAllTimersAsync()
+    await promise
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- export internal helpers `classifyError` and `withRetry`
- add unit tests covering error classification
- add unit tests for retry logic with exponential backoff

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404df2c8408321b5f077127a55c80c