### PR TITLE
Add AppError and global error handling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { Footer } from "@/components/layout/footer";
 import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { AdminProvider } from "@/contexts/AdminContext";
+import { ErrorBoundary } from "@/components/error-boundary";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -32,10 +33,12 @@ export default function RootLayout({
         >
           <AuthProvider>
             <AdminProvider>
-              <Header />
-              <main className="min-h-screen">{children}</main>
-              <Footer />
-              <Toaster />
+              <ErrorBoundary>
+                <Header />
+                <main className="min-h-screen">{children}</main>
+                <Footer />
+                <Toaster />
+              </ErrorBoundary>
             </AdminProvider>
           </AuthProvider>
         </ThemeProvider>

--- a/components/admin/connection-troubleshooter.tsx
+++ b/components/admin/connection-troubleshooter.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 import { useAdmin } from "@/contexts/AdminContext";
+import { AppError, logError } from "@/error";
 
 export function ConnectionTroubleshooter() {
   const [isRunningTest, setIsRunningTest] = useState(false);
@@ -151,8 +152,9 @@ export function ConnectionTroubleshooter() {
       }
       
     } catch (error) {
-      console.error('Connection tests failed:', error);
-      testResults.details.main = error;
+      const appError = error instanceof AppError ? error : new AppError(error.message || 'Tests échoués');
+      logError(appError);
+      testResults.details.main = appError;
     } finally {
       setResults(testResults);
       setIsRunningTest(false);
@@ -173,12 +175,13 @@ export function ConnectionTroubleshooter() {
         ...prev,
         reloadSuccess: true
       }));
-    } catch (error) {
-      console.error('Failed to reload data:', error);
+    } catch (error: any) {
+      const appError = error instanceof AppError ? error : new AppError(error.message || 'Erreur inconnue');
+      logError(appError);
       setResults(prev => ({
         ...prev,
         reloadSuccess: false,
-        reloadError: error
+        reloadError: appError
       }));
     } finally {
       setIsRunningTest(false);

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from 'react';
+import { logError } from '@/error';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    logError(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <div className="p-4 text-center">
+            <p className="text-destructive">Une erreur est survenue. Veuillez réessayer plus tard.</p>
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@/lib/supabase';
 import { AuthContextType, AuthProviderProps, AuthState, UserProfile } from '@/lib/types/auth-types';
 import { Session, User } from '@supabase/supabase-js';
 import { useToast } from '@/hooks/use-toast';
+import { AppError, logError } from '@/error';
 
 // Create context with default values
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -26,7 +27,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const { data: { session }, error } = await supabase.auth.getSession();
         
         if (error) {
-          console.error('Error fetching session:', error);
+          const appError = new AppError('Error fetching session', error.code);
+          logError(appError);
           return;
         }
 
@@ -52,7 +54,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           setAuthState({ user: null, session: null, isLoading: false });
         }
       } catch (error) {
-        console.error('Auth initialization error:', error);
+        const appError = new AppError('Auth initialization error');
+        logError(appError);
         setAuthState({ user: null, session: null, isLoading: false });
       }
     };
@@ -150,12 +153,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       return { data, error: null };
     } catch (error: any) {
+      const appError = new AppError(error.message || 'Erreur lors de l\'inscription', error.code);
+      logError(appError);
       toast({
         variant: "destructive",
         title: "Erreur d'inscription",
-        description: error.message || "Une erreur est survenue lors de l'inscription.",
+        description: appError.message,
       });
-      return { data: null, error };
+      return { data: null, error: appError };
     }
   };
 
@@ -168,14 +173,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       });
 
       if (error) {
-        // Return the error instead of throwing it, let the component handle display
-        return { data: null, error };
+        const appError = new AppError(error.message, error.code);
+        logError(appError);
+        return { data: null, error: appError };
       }
 
       return { data, error: null };
     } catch (error: any) {
-      // Just return the error without showing a toast
-      return { data: null, error };
+      const appError = new AppError(error.message, error.code);
+      logError(appError);
+      return { data: null, error: appError };
     }
   };
 
@@ -193,10 +200,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         throw error;
       }
     } catch (error: any) {
+      const appError = new AppError(error.message || 'Erreur de connexion Google', error.code);
+      logError(appError);
       toast({
         variant: "destructive",
         title: "Erreur de connexion Google",
-        description: error.message || "Une erreur est survenue lors de la connexion avec Google.",
+        description: appError.message,
       });
     }
   };
@@ -210,10 +219,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       }
       setAuthState({ user: null, session: null, isLoading: false });
     } catch (error: any) {
+      const appError = new AppError(error.message || 'Erreur de déconnexion', error.code);
+      logError(appError);
       toast({
         variant: "destructive",
         title: "Erreur de déconnexion",
-        description: error.message || "Une erreur est survenue lors de la déconnexion.",
+        description: appError.message,
       });
     }
   };
@@ -236,12 +247,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       return { data, error: null };
     } catch (error: any) {
+      const appError = new AppError(error.message || "Erreur de réinitialisation", error.code);
+      logError(appError);
       toast({
         variant: "destructive",
         title: "Erreur de réinitialisation",
-        description: error.message || "Une erreur est survenue lors de l'envoi de l'email de réinitialisation.",
+        description: appError.message,
       });
-      return { data: null, error };
+      return { data: null, error: appError };
     }
   };
 
@@ -279,12 +292,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       return { data, error: null };
     } catch (error: any) {
+      const appError = new AppError(error.message || "Erreur de mise à jour", error.code);
+      logError(appError);
       toast({
         variant: "destructive",
         title: "Erreur de mise à jour",
-        description: error.message || "Une erreur est survenue lors de la mise à jour du profil.",
+        description: appError.message,
       });
-      return { data: null, error };
+      return { data: null, error: appError };
     }
   };
 
@@ -306,12 +321,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       return { data, error: null };
     } catch (error: any) {
+      const appError = new AppError(error.message || "Erreur de mise à jour", error.code);
+      logError(appError);
       toast({
         variant: "destructive",
         title: "Erreur de mise à jour",
-        description: error.message || "Une erreur est survenue lors de la modification du mot de passe.",
+        description: appError.message,
       });
-      return { data: null, error };
+      return { data: null, error: appError };
     }
   };
 
@@ -332,7 +349,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new AppError('useAuth must be used within an AuthProvider');
   }
   return context;
 };

--- a/error/AppError.ts
+++ b/error/AppError.ts
@@ -1,0 +1,15 @@
+export class AppError extends Error {
+  code?: string;
+  details?: any;
+
+  constructor(message: string, code?: string, details?: any) {
+    super(message);
+    this.name = 'AppError';
+    this.code = code;
+    this.details = details;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AppError);
+    }
+  }
+}

--- a/error/index.ts
+++ b/error/index.ts
@@ -1,0 +1,2 @@
+export * from './AppError';
+export * from './logger';

--- a/error/logger.ts
+++ b/error/logger.ts
@@ -1,0 +1,10 @@
+import { AppError } from './AppError';
+
+export function logError(error: Error | AppError) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(error);
+  } else {
+    // In real apps we could send the error to a monitoring service
+    console.error(error);
+  }
+}

--- a/lib/types/admin-types.ts
+++ b/lib/types/admin-types.ts
@@ -116,11 +116,13 @@ export interface DashboardData {
   }[];
 }
 
+import { AppError } from '@/error';
+
 export interface AdminContextType {
   isAdmin: boolean;
   isLoading: boolean;
   offlineMode: boolean;
-  error: string | null;
+  error: AppError | null;
   users: AdminUser[];
   courses: CourseData[];
   modules: ModuleData[];

--- a/lib/types/auth-types.ts
+++ b/lib/types/auth-types.ts
@@ -15,14 +15,16 @@ export type AuthState = {
   isLoading: boolean;
 };
 
+import { AppError } from '@/error';
+
 export type AuthContextType = AuthState & {
-  signUp: (email: string, password: string, metadata?: any) => Promise<{ data: any | null; error: any | null }>;
-  signIn: (email: string, password: string) => Promise<{ data: any | null; error: any | null }>;
+  signUp: (email: string, password: string, metadata?: any) => Promise<{ data: any | null; error: AppError | null }>;
+  signIn: (email: string, password: string) => Promise<{ data: any | null; error: AppError | null }>;
   signInWithGoogle: () => Promise<void>;
   signOut: () => Promise<void>;
-  resetPassword: (email: string) => Promise<{ data: any | null; error: any | null }>;
-  updateProfile: (updates: Partial<UserProfile>) => Promise<{ data: any | null; error: any | null }>;
-  updatePassword: (password: string) => Promise<{ data: any | null; error: any | null }>;
+  resetPassword: (email: string) => Promise<{ data: any | null; error: AppError | null }>;
+  updateProfile: (updates: Partial<UserProfile>) => Promise<{ data: any | null; error: AppError | null }>;
+  updatePassword: (password: string) => Promise<{ data: any | null; error: AppError | null }>;
 };
 
 export type AuthProviderProps = {


### PR DESCRIPTION
## Summary
- implement `error` utilities with `AppError` class and logger
- add client `ErrorBoundary` and use in layout
- refactor contexts to use `AppError`
- handle `AppError` in connection troubleshooter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404dea8a8c8321a9e2dbbdabf7418a