### PR TITLE
Add migration to fix search_path warnings

### DIFF
--- a/supabase/migrations/20250604050553_search_path_fix.sql
+++ b/supabase/migrations/20250604050553_search_path_fix.sql
@@ -1,0 +1,135 @@
+-- Migration to set search_path for functions flagged by Supabase linter
+
+-- handle_new_user
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, full_name, avatar_url)
+  VALUES (
+    new.id,
+    new.raw_user_meta_data->>'full_name',
+    new.raw_user_meta_data->>'avatar_url'
+  );
+  RETURN new;
+END;
+$$;
+
+-- is_admin
+CREATE OR REPLACE FUNCTION is_admin(user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1
+    FROM user_roles
+    WHERE user_roles.user_id = $1 AND role = 'admin'
+  );
+END;
+$$;
+
+-- get_user_stats
+CREATE OR REPLACE FUNCTION get_user_stats()
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'total_users', (SELECT count(*) FROM profiles),
+    'active_users', (SELECT count(*) FROM auth.users WHERE last_sign_in_at > (now() - interval '30 days')),
+    'completed_courses', (
+      SELECT count(*)
+      FROM user_module_progress
+      WHERE completed = true
+    ),
+    'average_completion_rate', (
+      SELECT COALESCE(
+        ROUND(AVG(
+          CASE WHEN total_modules > 0
+          THEN (completed_modules::numeric / total_modules) * 100
+          ELSE 0 END
+        )::numeric, 0),
+        0
+      )
+      FROM (
+        SELECT
+          p.id,
+          COUNT(CASE WHEN ump.completed THEN 1 END) as completed_modules,
+          COUNT(m.id) as total_modules
+        FROM profiles p
+        LEFT JOIN user_module_progress ump ON p.id = ump.user_id
+        LEFT JOIN modules m ON m.id = ump.module_id
+        GROUP BY p.id
+      ) as user_stats
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$$;
+
+-- get_course_stats
+CREATE OR REPLACE FUNCTION get_course_stats()
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  result json;
+  total_courses_count integer;
+  published_courses_count integer;
+  total_modules_count integer;
+  most_popular_course_id text;
+  most_popular_course_title text;
+  most_popular_course_students_count integer;
+BEGIN
+  SELECT COUNT(*) INTO total_courses_count FROM courses;
+  SELECT COUNT(*) INTO published_courses_count FROM courses WHERE status = 'published';
+  SELECT COUNT(*) INTO total_modules_count FROM modules;
+
+  SELECT
+    c.id::text,
+    c.title,
+    COUNT(DISTINCT ump.user_id)::integer as students_count
+  INTO
+    most_popular_course_id,
+    most_popular_course_title,
+    most_popular_course_students_count
+  FROM courses c
+  LEFT JOIN modules m ON c.id = m.course_id
+  LEFT JOIN user_module_progress ump ON m.id = ump.module_id
+  GROUP BY c.id, c.title
+  ORDER BY students_count DESC
+  LIMIT 1;
+
+  IF most_popular_course_id IS NULL THEN
+    most_popular_course_id := '1';
+    most_popular_course_title := 'Introduction à l''IA';
+    most_popular_course_students_count := 248;
+  END IF;
+
+  SELECT json_build_object(
+    'total_courses', COALESCE(total_courses_count, 15),
+    'published_courses', COALESCE(published_courses_count, 12),
+    'total_modules', COALESCE(total_modules_count, 42),
+    'most_popular_course', json_build_object(
+      'id', most_popular_course_id,
+      'title', most_popular_course_title,
+      'students_count', most_popular_course_students_count
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add migration to define `search_path` for key functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68405701a1408321a100aa08935fe3b4