### PR TITLE
Remove console.log statements in AdminContext

### DIFF
--- a/contexts/AdminContext.tsx
+++ b/contexts/AdminContext.tsx
@@ -1571,9 +1571,9 @@ export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
 
   // Écouter les changements de connectivité réseau
   useEffect(() => {
-    const handleOnline = () => {
-      console.log("Application is back online");
-      setOfflineMode(false);
+      const handleOnline = () => {
+        logError(new Error("Application is back online"));
+        setOfflineMode(false);
       // Recharger les données si nous sommes de retour en ligne
       if (isAdmin) {
         loadUsers();
@@ -1583,9 +1583,9 @@ export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
       }
     };
     
-    const handleOffline = () => {
-      console.log("Application is offline");
-      setOfflineMode(true);
+      const handleOffline = () => {
+        logError(new Error("Application is offline"));
+        setOfflineMode(true);
       setError(new AppError("Mode hors ligne : certaines fonctionnalités peuvent être limitées"));
     };
     


### PR DESCRIPTION
## Summary
- use `logError` instead of `console.log` when the app goes online/offline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68407d11f01c8321bc364cb817bf2c1d