### PR TITLE
Improve logging and add tests

### DIFF
--- a/error/logger.ts
+++ b/error/logger.ts
@@ -1,10 +1,51 @@
 import { AppError } from './AppError';
 
-export function logError(error: Error | AppError) {
+export type LogLevel = 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  level: LogLevel;
+  message: string;
+  timestamp: string;
+  details?: any;
+}
+
+/**
+ * Send a log entry to the monitoring endpoint. Falls back to console logging
+ * during development.
+ */
+export async function logEvent(
+  level: LogLevel,
+  message: string,
+  details?: any
+) {
+  const entry: LogEntry = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    details
+  };
+
   if (process.env.NODE_ENV !== 'production') {
-    console.error(error);
-  } else {
-    // In real apps we could send the error to a monitoring service
-    console.error(error);
+    const fn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+    fn(entry);
   }
+
+  if (typeof fetch === 'function') {
+    try {
+      await fetch('/api/logs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(entry)
+      });
+    } catch {
+      // Ignore network errors when sending logs
+    }
+  }
+}
+
+export function logError(error: Error | AppError) {
+  logEvent('error', error.message, {
+    code: (error as AppError).code,
+    stack: error.stack
+  });
 }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { logEvent, logError } from '@/error/logger';
+
+describe('logger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  it('sends log entry via fetch', async () => {
+    await logEvent('info', 'test message', { foo: 'bar' });
+    expect(global.fetch).toHaveBeenCalled();
+    const [url, options] = (global.fetch as any).mock.calls[0];
+    expect(url).toBe('/api/logs');
+    const body = JSON.parse(options.body);
+    expect(body.level).toBe('info');
+    expect(body.message).toBe('test message');
+    expect(body.details.foo).toBe('bar');
+  });
+
+  it('logError logs with level error', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await logError(new Error('boom'));
+    expect(spy).toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- expand logger to support log levels and send events to monitoring endpoint
- add unit tests for the new logging functionality

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6840ac133dac83219112b4a0cd6217dc