### PR TITLE
Add logs API endpoint

### DIFF
--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await request.json();
+    console.log('API log entry:', payload);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Error while logging entry:', err);
+    return NextResponse.json({ success: false }, { status: 400 });
+  }
+}


### PR DESCRIPTION
## Summary
- add `app/api/logs` route

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684116f8c6e883218b3422d99e62019d