### PR TITLE
Fix admin data loading effect

### DIFF
--- a/contexts/AdminContext.tsx
+++ b/contexts/AdminContext.tsx
@@ -1606,7 +1606,7 @@ export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
       loadCoupons();
       loadDashboardData();
     }
-  }, [isAdmin, isLoading, loadCourses, loadCoupons, loadDashboardData, loadUsers]);
+  }, [isAdmin, loadCourses, loadCoupons, loadDashboardData, loadUsers]);
 
   const value = {
     isAdmin,


### PR DESCRIPTION
## Summary
- prevent repeated admin data fetches by removing `isLoading` from the dependency array

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684129f9966483219a0f95c1fd4d04f0