### PR TITLE
Improve login error handling

### DIFF
--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -27,6 +27,7 @@ type FormValues = z.infer<typeof formSchema>;
 export function SignInForm() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [invalidCredentials, setInvalidCredentials] = useState(false);
   const { signIn, signInWithGoogle } = useAuth();
   const router = useRouter();
 
@@ -46,11 +47,17 @@ export function SignInForm() {
   const onSubmit = async (data: FormValues) => {
     setIsLoading(true);
     setError(null);
+    setInvalidCredentials(false);
 
     try {
       const { error } = await signIn(data.email, data.password);
-      
+
       if (error) {
+        if (error.code === 'invalid_login_credentials') {
+          setInvalidCredentials(true);
+          setError('Adresse email ou mot de passe incorrect');
+          return;
+        }
         throw error;
       }
       
@@ -108,7 +115,7 @@ export function SignInForm() {
               type="email"
               placeholder="votreemail@exemple.com"
               {...register("email")}
-              className={errors.email ? "border-red-500" : ""}
+              className={errors.email || invalidCredentials ? "border-red-500" : ""}
               disabled={isLoading}
             />
             {errors.email && (
@@ -131,7 +138,7 @@ export function SignInForm() {
               type="password"
               placeholder="••••••••"
               {...register("password")}
-              className={errors.password ? "border-red-500" : ""}
+              className={errors.password || invalidCredentials ? "border-red-500" : ""}
               disabled={isLoading}
             />
             {errors.password && (

--- a/tests/components/auth/signInForm.test.tsx
+++ b/tests/components/auth/signInForm.test.tsx
@@ -1,19 +1,37 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SignInForm } from '@/components/auth/SignInForm';
 
+const signInMock = vi.fn().mockResolvedValue({ data: {}, error: null });
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ signIn: vi.fn().mockResolvedValue({ data: {}, error: null }), signInWithGoogle: vi.fn() })
+  useAuth: () => ({ signIn: signInMock, signInWithGoogle: vi.fn() })
 }));
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 describe('SignInForm', () => {
+  beforeEach(() => {
+    signInMock.mockResolvedValue({ data: {}, error: null });
+  });
   it('displays validation errors', async () => {
     render(<SignInForm />);
     const submit = screen.getByRole('button', { name: /se connecter/i });
     await userEvent.click(submit);
     expect(await screen.findAllByText(/doit contenir/i)).toBeTruthy();
+  });
+
+  it('shows credential error from api', async () => {
+    signInMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: 'invalid_login_credentials', message: 'Invalid login credentials' }
+    });
+
+    render(<SignInForm />);
+    await userEvent.type(screen.getByLabelText(/^adresse email/i), 'john@example.com');
+    await userEvent.type(screen.getByLabelText(/^mot de passe$/i), 'wrongpass');
+    await userEvent.click(screen.getByRole('button', { name: /se connecter/i }));
+
+    expect(await screen.findByText(/adresse email ou mot de passe incorrect/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- highlight invalid login attempts
- return a specific message for wrong credentials
- test error rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684135f2514883218de019bfbcdad9e0